### PR TITLE
Add calls to VirtualAllocEx to change the headers' and the sections' …

### DIFF
--- a/ProcessHollowing.hpp
+++ b/ProcessHollowing.hpp
@@ -183,6 +183,7 @@ private:
     PIMAGE_SECTION_HEADER FindTargetProcessSection(const std::string& sectionName);
     void RelocateTargetProcess(ULONGLONG baseAddressesDelta, PVOID processBaseAddress);
     void UpdateBaseAddressInTargetPEB(PVOID processNewBaseAddress);
+    DWORD SectionCharacteristicsToMemoryProtections(DWORD characteristics);
     bool AreProcessesCompatible();
     PVOID ReallocateTargetProcessMemory(unsigned int newMemorySize);
     bool IsProcess64Bit(const HANDLE processHandle);


### PR DESCRIPTION
Make the sections to have the corresponding permissions according to the characteristics in the Section Table, and make the PE headers to have read/write protections.